### PR TITLE
Don't include the erlang_pmp pid when profiling all processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ FlameGraph/flamegraph.pl /tmp/erlang_pmp.trace > /tmp/erlang_pmp.svg
 
 #### Examples
 
+First it is good to increase the depth of captured call stacks, which by default are 8 frames only.
+
+```
+erlang:system_flag(backtrace_depth, 128).
+```
+
 The below example is useful in scenarios when we want to sample all processes to get an idea of the overall system profile. We omit the `waiting` state to focus on busy processes only.
 
 ```

--- a/README.md
+++ b/README.md
@@ -31,3 +31,17 @@ The output of `erlang_pmp` is meant to be used with [FlameGraph stack trace visu
 git clone https://github.com/brendangregg/FlameGraph.git
 FlameGraph/flamegraph.pl /tmp/erlang_pmp.trace > /tmp/erlang_pmp.svg
 ```
+
+#### Examples
+
+The below example is useful in scenarios when we want to sample all processes to get an idea of the overall system profile. We omit the `waiting` state to focus on busy processes only.
+
+```
+erlang_pmp:profile([{duration, 30}, {include_statuses, [exiting, garbage_collecting, running, runnable, suspended]}, {show_status, true}, {show_pid, true}]).
+```
+
+If the system has many processes, we sample stacks less frequently and don't show individual pids:
+
+```
+erlang_pmp:profile([{duration, 30}, {include_statuses, [exiting, garbage_collecting, running, runnable, suspended]}, {show_status, true}, {sleep,50}]).
+```

--- a/src/erlang_pmp.erl
+++ b/src/erlang_pmp.erl
@@ -110,5 +110,5 @@ sleep(Time) -> timer:sleep(Time).
 to_name([] = _Name, Pid) -> Pid;
 to_name(Name, _Pid) when is_atom(Name) -> Name.
 
-process_list(all) -> erlang:processes();
+process_list(all) -> erlang:processes() -- [self()];
 process_list([Pid | _] = Processes) when is_pid(Pid) -> Processes.


### PR DESCRIPTION
In some profiling scenarios time spent running erlang_pmp functions is relatively high and makes reading the flame graph harder. We are not interested in profiling the profiler anyway, so we can skip its pid.